### PR TITLE
Use slimmer k8s client, in-cluster client creation, use context for namespace

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,10 @@
 FROM alpine:latest
 
 ADD gzr /usr/local/bin/gzr
-ADD docker-config/kube.conf /root/.kube/config
 ADD docker-config/gzr.json /root/.gzr.json
 ADD start.sh /usr/local/bin/start.sh
-ADD https://storage.googleapis.com/kubernetes-release/release/v1.5.3/bin/linux/amd64/kubectl /usr/local/bin/kubectl
 
 RUN apk update && \
-    apk add bash && \
-    chmod +x /usr/local/bin/kubectl
+    apk add bash
 
 ENTRYPOINT ["start.sh"]

--- a/Dockerfile.builder
+++ b/Dockerfile.builder
@@ -1,8 +1,8 @@
-FROM golang:1.8-alpine
+FROM golang:1.9-alpine
 
 WORKDIR /go/src/github.com/bypasslane/gzr
 RUN apk update && \
-    apk add git nodejs make ca-certificates && \
+    apk add git nodejs nodejs-npm yarn make ca-certificates && \
     update-ca-certificates && \
     git config --global url."https://".insteadOf git:// && \
     git config --global url."https://".insteadOf ssh:// && \

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ build:
 	go build -i -o gzr
 
 build_web: build
-	cd gozer-web; npm i -g webpack; npm i; npm run build;
+	cd gozer-web; yarn global add webpack; yarn; yarn build;
 	boxedRice append -b=public --exec=./gzr
 
 install_build_deps:

--- a/cmd/web.go
+++ b/cmd/web.go
@@ -4,14 +4,14 @@ import (
 	"fmt"
 	"net/http"
 
-	"k8s.io/client-go/tools/clientcmd"
-
 	log "github.com/Sirupsen/logrus"
+	"github.com/bypasslane/boxedRice"
 	"github.com/bypasslane/gzr/comms"
 	"github.com/bypasslane/gzr/controllers"
 	"github.com/spf13/cobra"
-	"github.com/bypasslane/boxedRice"
 )
+
+// DefaultWebLogFormat sets logger to "json"|"text"
 const DefaultWebLogFormat = "json"
 
 // webCmd represents the web command
@@ -23,17 +23,15 @@ gzr web
 gzr web --port=<CUSTOM_PORT_NUMBER>
 	`,
 	PersistentPreRun: func(cmd *cobra.Command, args []string) {
-		setNamespace()
 		formatter, err := parseLogFormat(logFormat)
-		if err!=nil{
+		if err != nil {
 			erWithDetails(err, "Invalid formatter specified")
 		}
 		log.SetFormatter(formatter)
-		var connErr error
-		k8sConn, connErr = comms.NewK8sConnection(namespace)
-		if connErr != nil {
+		k8sClient, err = comms.NewK8sClient()
+		if err != nil {
 			// TODO: figure out the Cobra way to handle this
-			erWithDetails(connErr, "Problem establishing k8s connection")
+			erWithDetails(err, "problem establishing k8s connection")
 		}
 		setupImageStore()
 	},
@@ -52,29 +50,11 @@ func bindAndRun() {
 	boxedRiceConfig := &boxedRice.Config{
 		LocateOrder: []boxedRice.LocateMethod{boxedRice.LocateAppended, boxedRice.LocateWorkingDirectory},
 	}
-	http.ListenAndServe(portString, controllers.App(k8sConn, imageStore, boxedRiceConfig))
+	http.ListenAndServe(portString, controllers.App(k8sClient, imageStore, boxedRiceConfig))
 }
 
 func init() {
 	RootCmd.AddCommand(webCmd)
 	webCmd.Flags().IntVarP(&webPort, "port", "p", 9393, "the port to run the Gozer web interface on")
 	webCmd.Flags().StringVar(&logFormat, "log-format", DefaultWebLogFormat, "The log formatter to use - (json | text)")
-	webCmd.Flags().StringVarP(&namespace, "namespace", "n", "", "namespace to look for Deployments in")
-}
-
-// setNamespace checks the current context in k8's config if one has not been passed into
-// the command
-func setNamespace() {
-	cli, err := clientcmd.LoadFromFile(clientcmd.RecommendedHomeFile)
-	if err != nil {
-		er("Cannot load ~/.kube/config")
-	}
-	if namespace == "" { // If it's set from the flag, don't do anything
-		currentNamespace := cli.Contexts[cli.CurrentContext].Namespace
-		if currentNamespace != "" { // If it's set in the context, set it
-			namespace = currentNamespace
-		} else {
-			namespace = "default"
-		}
-	}
 }

--- a/comms/k8s.go
+++ b/comms/k8s.go
@@ -1,202 +1,124 @@
 package comms
 
 import (
+	"context"
 	"encoding/json"
 	e "errors"
 	"fmt"
+	"html/template"
 	"io"
+	"io/ioutil"
 	"os"
-	"text/template"
 
+	"github.com/ericchiang/k8s"
+	"github.com/ericchiang/k8s/apis/extensions/v1beta1"
+	"github.com/ghodss/yaml"
 	"github.com/pkg/errors"
-
-	"k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/pkg/apis/extensions/v1beta1"
-	"k8s.io/client-go/tools/clientcmd"
 )
 
 var (
-	ErrContainerNotFound        = e.New("Requested container couldn't be found")
 	ErrDeploymentNotFound       = e.New("Requested deployment couldn't be found")
 	ErrNoDeploymentsInNamespace = e.New("No deployments found in specified namespace")
 )
 
-// GzrDeployment is just here to let us declare methods on k8s Deployments
-type GzrDeployment v1beta1.Deployment
-
-// GzrDeploymentList is a collection of GzrDeployments
-type GzrDeploymentList struct {
-	Deployments []GzrDeployment `json:"deployments"`
-}
-
-// Serializer knows how to serialize for web (JSON) and CLI (templatized strings)
-type Serializer interface {
-	// SerializeForCLI writes templatized information to the provided io.Writer
-	SerializeForCLI(io.Writer) error
-	// SerializeForWire kicks out JSON as a byte slice
-	SerializeForWire() ([]byte, error)
-}
-
-// DeploymentContainerInfo holds information about a Deployment sufficient for updating a Pod's container by name
-type DeploymentContainerInfo struct {
-	// Namespace is the Deployment's k8s namespace
-	Namespace string
-	// DeploymentName is the name of the Deployment
-	DeploymentName string
-	// ContainerName is the name of a Pod's container in the Deployment spec
-	ContainerName string
-	// Image is the name of the image (current or intended) for the container identified by ContainerName
-	Image string
+// K8sClient is a wrapper around the *k8s.Client
+type K8sClient struct {
+	K *k8s.Client
 }
 
 // K8sCommunicator defines an interface for retrieving data from a k8s cluster
 type K8sCommunicator interface {
 	// ListDeployments returns the list of Deployments in the cluster
-	ListDeployments() (*GzrDeploymentList, error)
+	ListDeployments() (*v1beta1.DeploymentList, error)
 	// GetDeployment returns the Deployment matching the given name
-	GetDeployment(string) (*GzrDeployment, error)
+	GetDeployment(string) (*v1beta1.Deployment, error)
 	// UpdateDeployment updates the Deployment's container in the manner specified by the argument
-	UpdateDeployment(*DeploymentContainerInfo) (*GzrDeployment, error)
-	// GetNamespace returns the namespace
-	GetNamespace() string
+	UpdateDeployment(*v1beta1.Deployment) (*v1beta1.Deployment, error)
 }
 
-// K8sConnection implements the K8sCommunicator interface and holds a live connection to a k8s cluster
-type K8sConnection struct {
-	// clientset is a collection of Kubernetes API clients
-	clientset *kubernetes.Clientset
-	// namespace is the k8s namespace active for this connection used to talk
-	namespace string
-}
+// NewK8sClient returns an in-cluster K8sClient, if gzr is ran from outside of a K8's cluster it
+// falls back to looking at users kube config.
+func NewK8sClient() (*K8sClient, error) {
+	client := new(K8sClient)
+	k, err := k8s.NewInClusterClient()
 
-// NewK8sConnection returns a K8sConnection with an active v1.Clientset.
-//   - assumes that $HOME/.kube/config contains a legit Kubernetes config for an healthy k8s cluster.
-//   - panics if the configuration can't be used to connect to a k8s cluster.
-func NewK8sConnection(namespace string) (*K8sConnection, error) {
-	var k *K8sConnection
-	kubeconfig := fmt.Sprintf("%s/.kube/config", os.Getenv("HOME"))
-	config, err := clientcmd.BuildConfigFromFlags("", kubeconfig)
+	// https://github.com/ericchiang/k8s/blob/master/client.go#L251
+	// Currently there aren't any error types to check against, without warning the user we try to
+	// create a client using kube config when in-cluster client creation fails
 	if err != nil {
-		panic(err.Error())
+		kubeconfigPath := fmt.Sprintf("%s/.kube/config", os.Getenv("HOME"))
+		data, err := ioutil.ReadFile(kubeconfigPath)
+		if err != nil {
+			return nil, fmt.Errorf("read kubeconfig: %v", err)
+		}
+
+		// Unmarshal YAML into a Kubernetes config object.
+		var config k8s.Config
+		if err := yaml.Unmarshal(data, &config); err != nil {
+			return nil, fmt.Errorf("unmarshal kubeconfig: %v", err)
+		}
+		k, err = k8s.NewClient(&config)
+		if err != nil {
+			panic(err.Error())
+		}
 	}
-
-	clientset, err := kubernetes.NewForConfig(config)
-
-	if err != nil {
-		return k, err
-	}
-
-	k = &K8sConnection{
-		clientset: clientset,
-		namespace: namespace,
-	}
-
-	return k, nil
+	client.K = k
+	return client, nil
 }
 
-// GetDeployment returns a GzrDeployment matching the deploymentName in the given namespace
-func (k *K8sConnection) GetDeployment(deploymentName string) (*GzrDeployment, error) {
-	var gd *GzrDeployment
-	deployment, err := k.clientset.ExtensionsV1beta1().Deployments(k.GetNamespace()).Get(deploymentName, v1.GetOptions{})
+// GetDeployment returns a v1beta1.Deployment matching the deploymentName in current namespace
+func (client *K8sClient) GetDeployment(deploymentName string) (*v1beta1.Deployment, error) {
+	deployment, err := client.K.ExtensionsV1Beta1().GetDeployment(context.Background(), deploymentName, client.K.Namespace)
 	if err != nil {
-		return gd, errors.Wrapf(err, "Failed to get deployment %q in namespace %q", deployment, k.GetNamespace())
+		return nil, errors.Wrapf(err, "Failed to get deployment %q in namespace %q", deploymentName, client.K.Namespace)
 	}
-	gdp := GzrDeployment(*deployment)
-	gd = &gdp
-
-	return gd, err
+	return deployment, err
 }
 
-// GetNamespace returns the namespace for the connection
-func (k *K8sConnection) GetNamespace() string {
-	return k.namespace
+// ListDeployments returns a list of Deployments in current namespace
+func (client *K8sClient) ListDeployments() (*v1beta1.DeploymentList, error) {
+	deploymentList, err := client.K.ExtensionsV1Beta1().ListDeployments(context.Background(), client.K.Namespace)
+	if err != nil {
+		return nil, errors.Wrapf(err, "Failed to list deployments in namespace %q", client.K.Namespace)
+	}
+	return deploymentList, err
 }
 
 // UpdateDeployment updates a Deployment on the server to the structure represented by the argument
 // TODO: verify that requested image exists in the store
 // TODO: verify that requested image exists in the registry
-func (k *K8sConnection) UpdateDeployment(dci *DeploymentContainerInfo) (*GzrDeployment, error) {
-	var gd *GzrDeployment
-	var containerIndex int
-	found := false
-
-	deployment, err := k.clientset.ExtensionsV1beta1().Deployments(k.namespace).Get(dci.DeploymentName, v1.GetOptions{})
+func (client *K8sClient) UpdateDeployment(newDeployment *v1beta1.Deployment) (*v1beta1.Deployment, error) {
+	deployment, err := client.K.ExtensionsV1Beta1().GetDeployment(context.Background(), *newDeployment.Metadata.Name, client.K.Namespace)
 	// no Name in ObjectMeta means it was returned empty
-	if deployment.ObjectMeta.Name == "" {
-		return gd, errors.WithStack(ErrDeploymentNotFound)
+	if *deployment.Metadata.Name == "" {
+		return deployment, errors.WithStack(ErrDeploymentNotFound)
 	}
 
-	for index, container := range deployment.Spec.Template.Spec.Containers {
-		if container.Name == dci.ContainerName {
-			containerIndex = index
-			found = true
-		}
-	}
-
-	if !found {
-		return gd, errors.WithStack(ErrContainerNotFound)
-	}
-
-	deployment.Spec.Template.Spec.Containers[containerIndex].Image = dci.Image
-	deployment, err = k.clientset.ExtensionsV1beta1().Deployments(dci.Namespace).Update(deployment)
+	deployment, err = client.K.ExtensionsV1Beta1().UpdateDeployment(context.Background(), newDeployment)
 
 	if err != nil {
-		return gd, errors.Wrap(err, "Failed to update deployment")
+		return deployment, errors.Wrap(err, "Failed to update deployment")
 	}
 
-	gdp := GzrDeployment(*deployment)
-	gd = &gdp
-
-	return gd, nil
+	return deployment, nil
 }
 
-// ListDeployments returns the active k8s Deployments for the given namespace
-func (k *K8sConnection) ListDeployments() (*GzrDeploymentList, error) {
-	var gzrDeploymentList GzrDeploymentList
-	deploymentList, err := k.clientset.ExtensionsV1beta1().Deployments(k.GetNamespace()).List(v1.ListOptions{})
-	if err != nil {
-		return &gzrDeploymentList, errors.Wrapf(err, "Failed to get list of deployments in namespace %q", k.GetNamespace())
-	}
-
-	if len(deploymentList.Items) == 0 {
-		return nil, errors.WithStack(ErrNoDeploymentsInNamespace)
-	}
-
-	for _, deployment := range deploymentList.Items {
-		gzrDeploymentList.Deployments = append(gzrDeploymentList.Deployments, GzrDeployment(deployment))
-	}
-
-	return &gzrDeploymentList, nil
-}
-
-// SerializeForCLI takes an io.Writer and writes templatized data to it representing a Deployment
-func (d GzrDeployment) SerializeForCLI(wr io.Writer) error {
-	return errors.Wrap(d.cliTemplate().Execute(wr, d), "Failed to serialize deployment ")
-}
-
-// cliTemplate returns the template that will be used for serializing Deployment data for display in the CLI
-func (d GzrDeployment) cliTemplate() *template.Template {
+// SerializeDeployForCLI takes an io.Writer and writes templatized data to it representing a Deployment
+func SerializeDeployForCLI(deploy *v1beta1.Deployment, wr io.Writer) error {
 	t := template.New("Deployment CLI")
 	t, _ = t.Parse(`-------------------------
-Deployment: {{.ObjectMeta.Name}}
+Deployment: {{.Metadata.Name}}
   - replicas: {{.Spec.Replicas}}
   - containers: {{range .Spec.Template.Spec.Containers}}
     --name:  {{.Name}}
     --image: {{.Image}}
 {{end}}
 `)
-	return t
+	return errors.Wrap(t.Execute(wr, deploy), "Failed to serialize deployment ")
 }
 
-// SerializeForWire returns a JSON representation of the Deployment
-func (d GzrDeployment) SerializeForWire() ([]byte, error) {
-	data, err := json.Marshal(d)
-	return data, errors.Wrap(err, "Failed to convert deployment to json")
-}
-
-// SerializeForWire returns a JSON representation of the DeploymentList
-func (dl *GzrDeploymentList) SerializeForWire() ([]byte, error) {
-	data, err := json.Marshal(dl)
-	return data, errors.Wrap(err, "Failed to convert deployment list to json")
+// SerializeForWire returns a JSON representation of the obj
+func SerializeForWire(obj interface{}) ([]byte, error) {
+	data, err := json.Marshal(obj)
+	return data, errors.Wrap(err, "Failed to convert object to json")
 }

--- a/comms/mock_k8s_communicator.go
+++ b/comms/mock_k8s_communicator.go
@@ -1,28 +1,21 @@
 package comms
 
-type MockK8sCommunicator struct {
-	OnGetDeployment    func(string) (*GzrDeployment, error)
-	OnListDeployments  func() (*GzrDeploymentList, error)
-	OnUpdateDeployment func(*DeploymentContainerInfo) (*GzrDeployment, error)
+import "github.com/ericchiang/k8s/apis/extensions/v1beta1"
 
-	namespace string
+type MockK8sCommunicator struct {
+	OnGetDeployment    func(string) (*v1beta1.Deployment, error)
+	OnListDeployments  func() (*v1beta1.DeploymentList, error)
+	OnUpdateDeployment func(*v1beta1.Deployment) (*v1beta1.Deployment, error)
 }
 
-func (mock *MockK8sCommunicator) GetDeployment(deploymentName string) (*GzrDeployment, error) {
+func (mock *MockK8sCommunicator) GetDeployment(deploymentName string) (*v1beta1.Deployment, error) {
 	return mock.OnGetDeployment(deploymentName)
 }
 
-func (mock *MockK8sCommunicator) ListDeployments() (*GzrDeploymentList, error) {
+func (mock *MockK8sCommunicator) ListDeployments() (*v1beta1.DeploymentList, error) {
 	return mock.OnListDeployments()
 }
 
-func (mock *MockK8sCommunicator) UpdateDeployment(dci *DeploymentContainerInfo) (*GzrDeployment, error) {
-	return mock.OnUpdateDeployment(dci)
-}
-
-func (mock *MockK8sCommunicator) GetNamespace() string {
-	if mock.namespace == "" {
-		return "default"
-	}
-	return mock.namespace
+func (mock *MockK8sCommunicator) UpdateDeployment(deployment *v1beta1.Deployment) (*v1beta1.Deployment, error) {
+	return mock.OnUpdateDeployment(deployment)
 }

--- a/controllers/app.go
+++ b/controllers/app.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/bypasslane/boxedRice"
 	log "github.com/Sirupsen/logrus"
+	"github.com/bypasslane/boxedRice"
 	"github.com/bypasslane/gzr/comms"
 	"github.com/bypasslane/gzr/middleware"
 	"github.com/gorilla/mux"
@@ -14,19 +14,20 @@ import (
 	"github.com/urfave/negroni"
 )
 
-//Allows for dependency injection of boxedRice.Config,
+// Allows for dependency injection of boxedRice.Config,
 // preventing errors during tests when a public folder isn't found
 type staticFileBoxConfig interface {
-	MustFindBox(boxName string)(*boxedRice.Box)
+	MustFindBox(boxName string) *boxedRice.Box
 }
 
-func App(k8sConn comms.K8sCommunicator, imageStore comms.GzrMetadataStore, boxedRiceConfig staticFileBoxConfig) http.Handler {
+// App builds our web router/handler
+func App(k8sComm comms.K8sCommunicator, imageStore comms.GzrMetadataStore, boxedRiceConfig staticFileBoxConfig) http.Handler {
 	router := mux.NewRouter().StrictSlash(true).UseEncodedPath()
 
 	router.HandleFunc("/", homeHandler).Methods("GET")
-	router.HandleFunc("/deployments", listDeploymentsHandler(k8sConn)).Methods("GET")
-	router.HandleFunc("/deployments/{name}", getDeploymentHandler(k8sConn)).Methods("GET")
-	router.HandleFunc("/deployments/{name}", updateDeploymentHandler(k8sConn)).Methods("PUT")
+	router.HandleFunc("/deployments", listDeploymentsHandler(k8sComm)).Methods("GET")
+	router.HandleFunc("/deployments/{name}", getDeploymentHandler(k8sComm)).Methods("GET")
+	router.HandleFunc("/deployments/{name}", updateDeploymentHandler(k8sComm)).Methods("PUT")
 
 	router.HandleFunc("/images/{name}", getImagesHandler(imageStore)).Methods("GET")
 	router.HandleFunc("/images/{name}/{version}", getImageHandler(imageStore)).Methods("GET")

--- a/controllers/deployments_controller.go
+++ b/controllers/deployments_controller.go
@@ -2,11 +2,13 @@ package controllers
 
 import (
 	"encoding/json"
+	"fmt"
 	"net/http"
 
-	log "github.com/Sirupsen/logrus"
-
 	"github.com/bypasslane/gzr/comms"
+
+	log "github.com/Sirupsen/logrus"
+	"github.com/ericchiang/k8s/apis/extensions/v1beta1"
 	"github.com/gorilla/mux"
 	"github.com/pkg/errors"
 )
@@ -19,9 +21,9 @@ type UpdateDeploymentUserType struct {
 }
 
 // listDeploymentsHandler lists deployments in the Kubernetes instance
-func listDeploymentsHandler(k8sConn comms.K8sCommunicator) http.HandlerFunc {
+func listDeploymentsHandler(k8sComm comms.K8sCommunicator) http.HandlerFunc {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		deployments, err := k8sConn.ListDeployments()
+		deployments, err := k8sComm.ListDeployments()
 		// TODO: differentiate between legit errors and unhandleable errors
 		if err != nil {
 			logErrorFields(err).Error("Unable to list deployments")
@@ -36,7 +38,7 @@ func listDeploymentsHandler(k8sConn comms.K8sCommunicator) http.HandlerFunc {
 			return
 		}
 
-		jsonData, err := deployments.SerializeForWire()
+		jsonData, err := comms.SerializeForWire(deployments)
 
 		if err != nil {
 			logErrorFields(err).Error("Error serializing for wire")
@@ -50,7 +52,7 @@ func listDeploymentsHandler(k8sConn comms.K8sCommunicator) http.HandlerFunc {
 }
 
 // getDeploymentHandler gets a single Deployment by name from the Kubernetes instance
-func getDeploymentHandler(k8sConn comms.K8sCommunicator) http.HandlerFunc {
+func getDeploymentHandler(k8sComm comms.K8sCommunicator) http.HandlerFunc {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		name := mux.Vars(r)["name"]
 
@@ -59,7 +61,7 @@ func getDeploymentHandler(k8sConn comms.K8sCommunicator) http.HandlerFunc {
 			w.WriteHeader(http.StatusBadRequest)
 			w.Write([]byte("name param required for this path"))
 		}
-		deployment, err := k8sConn.GetDeployment(name)
+		deployment, err := k8sComm.GetDeployment(name)
 
 		if errors.Cause(err) == comms.ErrDeploymentNotFound {
 			logErrorFields(err).Warnf("Deployment not found for %q", name)
@@ -70,7 +72,7 @@ func getDeploymentHandler(k8sConn comms.K8sCommunicator) http.HandlerFunc {
 
 		// TODO: catch other kinds of errors
 
-		jsonData, err := deployment.SerializeForWire()
+		jsonData, err := comms.SerializeForWire(deployment)
 
 		if err != nil {
 			logErrorFields(err).Error("Error serializng for wire")
@@ -83,18 +85,19 @@ func getDeploymentHandler(k8sConn comms.K8sCommunicator) http.HandlerFunc {
 	})
 }
 
-// updateDeploymentHandler updates a specific container on a single Deployment to a given image
-func updateDeploymentHandler(k8sConn comms.K8sCommunicator) http.HandlerFunc {
+// updateDeploymentHandler updates a specific container on a single Deployment
+func updateDeploymentHandler(k8sComm comms.K8sCommunicator) http.HandlerFunc {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		var err error
-		var deployment *comms.GzrDeployment
+		var deployment *v1beta1.Deployment
+		var foundContainer bool
 		name := mux.Vars(r)["name"]
 
 		if name == "" {
 			log.Warn("name param required for this path")
 			w.WriteHeader(http.StatusBadRequest)
 		}
-		deployment, err = k8sConn.GetDeployment(name)
+		deployment, err = k8sComm.GetDeployment(name)
 
 		if errors.Cause(err) == comms.ErrDeploymentNotFound {
 			logErrorFields(err).Warn("Error getting deployment")
@@ -115,17 +118,22 @@ func updateDeploymentHandler(k8sConn comms.K8sCommunicator) http.HandlerFunc {
 			return
 		}
 
-		deployment, err = k8sConn.UpdateDeployment(userData.convertToDeploymentContainerInfo(k8sConn.GetNamespace(), name))
-
-		// TODO: more fine-grained error reporting
-		if errors.Cause(err) == comms.ErrContainerNotFound {
-			logErrorFields(err).Warn("Conatiner not found")
-			w.WriteHeader(http.StatusNotFound)
-			w.Write([]byte(err.Error()))
-			return
+		for containerIndex, container := range deployment.Spec.Template.Spec.Containers {
+			if *container.Name == userData.ContainerName {
+				foundContainer = true
+				*deployment.Spec.Template.Spec.Containers[containerIndex].Image = userData.Image
+				break
+			}
+		}
+		if !foundContainer {
+			logErrorFields(err).Warn("Could not find container with name %q", userData.ContainerName)
+			w.WriteHeader(http.StatusBadRequest)
+			w.Write([]byte(fmt.Sprintf("Could not find container with name %q", userData.ContainerName)))
 		}
 
-		jsonData, err := deployment.SerializeForWire()
+		deployment, err = k8sComm.UpdateDeployment(deployment)
+
+		jsonData, err := comms.SerializeForWire(deployment)
 
 		// TODO: more fine-grained error reporting
 		if err != nil {
@@ -137,14 +145,4 @@ func updateDeploymentHandler(k8sConn comms.K8sCommunicator) http.HandlerFunc {
 
 		w.Write(jsonData)
 	})
-}
-
-// convertToDeploymentContainerInfo creates a DeploymentContainerInfo struct
-func (updateData *UpdateDeploymentUserType) convertToDeploymentContainerInfo(namespace string, deploymentName string) *comms.DeploymentContainerInfo {
-	return &comms.DeploymentContainerInfo{
-		Namespace:      namespace,
-		DeploymentName: deploymentName,
-		ContainerName:  updateData.ContainerName,
-		Image:          updateData.Image,
-	}
 }

--- a/controllers/test_helpers.go
+++ b/controllers/test_helpers.go
@@ -6,34 +6,31 @@ import (
 	"strings"
 
 	"github.com/bypasslane/gzr/comms"
+	"github.com/ericchiang/k8s/apis/extensions/v1beta1"
 )
 
-func emptyDeploymentsList() (*comms.GzrDeploymentList, error) {
+func emptyDeploymentsList() (**v1beta1.DeploymentList, error) {
 	return nil, nil
 }
 
-func populatedDeploymentsList() (*comms.GzrDeploymentList, error) {
-	return &comms.GzrDeploymentList{}, nil
+func populatedDeploymentsList() (*v1beta1.DeploymentList, error) {
+	return &v1beta1.DeploymentList{}, nil
 }
 
-func emptyGetDeployment(deploymentName string) (*comms.GzrDeployment, error) {
+func emptyGetDeployment(deploymentName string) (*v1beta1.Deployment, error) {
 	return nil, comms.ErrDeploymentNotFound
 }
 
-func populatedGetDeployment(deploymentName string) (*comms.GzrDeployment, error) {
-	return &comms.GzrDeployment{}, nil
+func populatedGetDeployment(deploymentName string) (*v1beta1.Deployment, error) {
+	return &v1beta1.Deployment{}, nil
 }
 
-func successfulUpdateDeployment(dci *comms.DeploymentContainerInfo) (*comms.GzrDeployment, error) {
-	return &comms.GzrDeployment{}, nil
+func successfulUpdateDeployment(newDeployment *v1beta1.Deployment) (*v1beta1.Deployment, error) {
+	return &v1beta1.Deployment{}, nil
 }
 
-func failUpdateDeploymentNoDeployment(dci *comms.DeploymentContainerInfo) (*comms.GzrDeployment, error) {
-	return &comms.GzrDeployment{}, comms.ErrDeploymentNotFound
-}
-
-func failUpdateDeploymentNoContainer(dci *comms.DeploymentContainerInfo) (*comms.GzrDeployment, error) {
-	return &comms.GzrDeployment{}, comms.ErrContainerNotFound
+func failUpdateDeploymentNoDeployment(newDeployment *v1beta1.Deployment) (*v1beta1.Deployment, error) {
+	return &v1beta1.Deployment{}, comms.ErrDeploymentNotFound
 }
 
 // Sends an HTTP request to provided server:

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 149938d9736bbb7a5f046b686fb686ad730cab27640b33222ae70dd89045ba25
-updated: 2017-07-05T16:16:14.752242684-05:00
+hash: b37bdca4c2f30754a361a73c8bcec521194503cd8a5e5c4852ac8c4388b3d9fd
+updated: 2017-10-25T09:01:19.556239386-05:00
 imports:
 - name: github.com/beorn7/perks
   version: 4c0e84591b9aa9e6dcfdf3e020114cd81f89d5f9
@@ -22,47 +22,48 @@ imports:
   - pkg/tlsutil
 - name: github.com/daaku/go.zipexe
   version: a5fe2436ffcb3236e175e5149162b41cd28bd27d
-- name: github.com/davecgh/go-spew
-  version: 5215b55f46b2b919f50a1df0eaa5886afe4e3b3d
+- name: github.com/ericchiang/k8s
+  version: 68b0248f880c5967d1ba7166486cb216af849b15
   subpackages:
-  - spew
-- name: github.com/docker/distribution
-  version: cd27f179f2c10c5d300e6d09025b538c475b0d51
-  subpackages:
-  - digest
-  - reference
-- name: github.com/emicklei/go-restful
-  version: 09691a3b6378b740595c1002f40c34dd5f218a22
-  subpackages:
-  - log
-  - swagger
+  - api/resource
+  - api/unversioned
+  - api/v1
+  - apis/apps/v1alpha1
+  - apis/apps/v1beta1
+  - apis/authentication/v1
+  - apis/authentication/v1beta1
+  - apis/authorization/v1
+  - apis/authorization/v1beta1
+  - apis/autoscaling/v1
+  - apis/autoscaling/v2alpha1
+  - apis/batch/v1
+  - apis/batch/v2alpha1
+  - apis/certificates/v1alpha1
+  - apis/certificates/v1beta1
+  - apis/extensions/v1beta1
+  - apis/imagepolicy/v1alpha1
+  - apis/meta/v1
+  - apis/policy/v1alpha1
+  - apis/policy/v1beta1
+  - apis/rbac/v1alpha1
+  - apis/rbac/v1beta1
+  - apis/settings/v1alpha1
+  - apis/storage/v1
+  - apis/storage/v1beta1
+  - runtime
+  - runtime/schema
+  - util/intstr
+  - watch/versioned
 - name: github.com/fsnotify/fsnotify
-  version: f12c6236fe7b5cf6bcf30e5935d08cb079d78334
+  version: 629574ca2a5df945712d3079857300b5e4da0236
 - name: github.com/ghodss/yaml
-  version: 73d445a93680fa1a78ae23a5839bad48f32ba1ee
-- name: github.com/go-openapi/jsonpointer
-  version: 46af16f9f7b149af66e5d1bd010e3574dc06de98
-- name: github.com/go-openapi/jsonreference
-  version: 13c6e3589ad90f49bd3e3bbe2c2cb3d7a4142272
-- name: github.com/go-openapi/spec
-  version: 6aced65f8501fe1217321abf0749d354824ba2ff
-- name: github.com/go-openapi/swag
-  version: 1d0bd113de87027671077d3c71eb3ac5d7dbba72
-- name: github.com/gogo/protobuf
-  version: e18d7aa8f8c624c915db340349aad4c49b10d173
-  subpackages:
-  - proto
-  - sortkeys
-- name: github.com/golang/glog
-  version: 44145f04b68cf362d9c4df2182967c2275eaefed
+  version: 0ca9ea5df5451ffdf184b4428c902747c2c11cd7
 - name: github.com/golang/protobuf
   version: 6a1fa9404c0aebf36c879bc50152edcc953910d2
   subpackages:
   - jsonpb
   - proto
   - ptypes/struct
-- name: github.com/google/gofuzz
-  version: 44d81051d367757e1c7c6a5a86423ece9afcf63c
 - name: github.com/gorilla/context
   version: 1ea25387ff6f684839d82767c1733ff4d4d15d0a
 - name: github.com/gorilla/mux
@@ -86,26 +87,14 @@ imports:
   - json/parser
   - json/scanner
   - json/token
-- name: github.com/howeyc/gopass
-  version: 3ca23474a7c7203e0a0a070fd33508f6efdb9b3d
-- name: github.com/imdario/mergo
-  version: 6633656539c1639d9d78127b7d47c622b5d7b6dc
 - name: github.com/inconshreveable/mousetrap
   version: 76626ae9c91c4f2a10f34cad8ce83ea42c93bb75
-- name: github.com/juju/ratelimit
-  version: 77ed1c8a01217656d2080ad51981f6e99adaa177
 - name: github.com/kardianos/osext
   version: 9d302b58e975387d0b4d9be876622c86cefe64be
 - name: github.com/kr/fs
   version: 2788f0dbd16903de03cb8186e5c7d97b69ad387b
 - name: github.com/magiconair/properties
   version: 61b492c03cf472e0c6419be5899b8e0dc28b1b88
-- name: github.com/mailru/easyjson
-  version: d5b7844b561a7bc640052f1b935f7b800330d7e0
-  subpackages:
-  - buffer
-  - jlexer
-  - jwriter
 - name: github.com/matttproud/golang_protobuf_extensions
   version: c12348ce28de40eed0136aa2b644d0ee0650e56c
   subpackages:
@@ -138,10 +127,6 @@ imports:
   - model
 - name: github.com/prometheus/procfs
   version: 1878d9fbb537119d24b21ca07effd591627cd160
-- name: github.com/PuerkitoBio/purell
-  version: 8a290539e2e8629dbc4e6bad948158f790ec31f4
-- name: github.com/PuerkitoBio/urlesc
-  version: 5bd2802263f21d8788851d5305584c82a5c75d7e
 - name: github.com/Sirupsen/logrus
   version: ba1b36c82c5e05c4f912a88eab0dcd91a171688f
 - name: github.com/spf13/afero
@@ -159,10 +144,6 @@ imports:
   version: 6fd2ff4ff8dfcdf5556fbdc0ac0284408274b1a7
 - name: github.com/spf13/viper
   version: 16990631d4aa7e38f73dbbbf37fa13e67c648531
-- name: github.com/ugorji/go
-  version: ded73eae5db7e7a0ef6f55aace87a2873c5d2b74
-  subpackages:
-  - codec
 - name: github.com/urfave/negroni
   version: c0db5feaa33826cd5117930c8f4ee5c0f565eec6
 - name: go4.org
@@ -170,18 +151,15 @@ imports:
   subpackages:
   - reflectutil
 - name: golang.org/x/crypto
-  version: d172538b2cfce0c13cee31e647d0367aa8cd2486
+  version: 1351f936d976c60a0a48d728281922cf63eafb8d
   subpackages:
-  - curve25519
-  - ed25519
-  - ed25519/internal/edwards25519
+  - bcrypt
+  - blowfish
   - ssh
-  - ssh/terminal
 - name: golang.org/x/net
-  version: e90d6d0afc4c315a0d87a568ae68577cc15149a0
+  version: f2499483f923065a842d38eb4c7f1927e6fc6e6d
   subpackages:
   - context
-  - context/ctxhttp
   - http2
   - http2/hpack
   - idna
@@ -195,16 +173,8 @@ imports:
 - name: golang.org/x/text
   version: 2910a502d2bf9e43193af9d68ca516529614eed3
   subpackages:
-  - cases
-  - internal/tag
-  - language
-  - runes
-  - secure/bidirule
-  - secure/precis
   - transform
-  - unicode/bidi
   - unicode/norm
-  - width
 - name: google.golang.org/grpc
   version: 777daa17ff9b5daef1cfdf915088a2ada3332bf0
   subpackages:
@@ -216,138 +186,6 @@ imports:
   - naming
   - peer
   - transport
-- name: gopkg.in/inf.v0
-  version: 3887ee99ecf07df5b447e9b00d9c0b2adaa9f3e4
 - name: gopkg.in/yaml.v2
   version: e4d366fc3c7938e2958e662b4258c7a89e1f0e3e
-- name: k8s.io/apimachinery
-  version: 85ace5365f33b16fc735c866a12e3c765b9700f2
-  subpackages:
-  - pkg/api/equality
-  - pkg/api/errors
-  - pkg/api/meta
-  - pkg/api/resource
-  - pkg/apimachinery
-  - pkg/apimachinery/announced
-  - pkg/apimachinery/registered
-  - pkg/apis/meta/v1
-  - pkg/apis/meta/v1/unstructured
-  - pkg/conversion
-  - pkg/conversion/queryparams
-  - pkg/fields
-  - pkg/labels
-  - pkg/openapi
-  - pkg/runtime
-  - pkg/runtime/schema
-  - pkg/runtime/serializer
-  - pkg/runtime/serializer/json
-  - pkg/runtime/serializer/protobuf
-  - pkg/runtime/serializer/recognizer
-  - pkg/runtime/serializer/streaming
-  - pkg/runtime/serializer/versioning
-  - pkg/selection
-  - pkg/types
-  - pkg/util/diff
-  - pkg/util/errors
-  - pkg/util/framer
-  - pkg/util/httpstream
-  - pkg/util/intstr
-  - pkg/util/json
-  - pkg/util/mergepatch
-  - pkg/util/net
-  - pkg/util/rand
-  - pkg/util/runtime
-  - pkg/util/sets
-  - pkg/util/strategicpatch
-  - pkg/util/validation
-  - pkg/util/validation/field
-  - pkg/util/wait
-  - pkg/util/yaml
-  - pkg/version
-  - pkg/watch
-  - third_party/forked/golang/json
-  - third_party/forked/golang/reflect
-- name: k8s.io/client-go
-  version: 99c1992389642cae4f41b931eca21827f9cc35b7
-  subpackages:
-  - discovery
-  - kubernetes
-  - kubernetes/scheme
-  - kubernetes/typed/apps/v1beta1
-  - kubernetes/typed/authentication/v1
-  - kubernetes/typed/authentication/v1beta1
-  - kubernetes/typed/authorization/v1
-  - kubernetes/typed/authorization/v1beta1
-  - kubernetes/typed/autoscaling/v1
-  - kubernetes/typed/autoscaling/v2alpha1
-  - kubernetes/typed/batch/v1
-  - kubernetes/typed/batch/v2alpha1
-  - kubernetes/typed/certificates/v1beta1
-  - kubernetes/typed/core/v1
-  - kubernetes/typed/extensions/v1beta1
-  - kubernetes/typed/policy/v1beta1
-  - kubernetes/typed/rbac/v1alpha1
-  - kubernetes/typed/rbac/v1beta1
-  - kubernetes/typed/settings/v1alpha1
-  - kubernetes/typed/storage/v1
-  - kubernetes/typed/storage/v1beta1
-  - pkg/api
-  - pkg/api/install
-  - pkg/api/v1
-  - pkg/apis/apps
-  - pkg/apis/apps/install
-  - pkg/apis/apps/v1beta1
-  - pkg/apis/authentication
-  - pkg/apis/authentication/install
-  - pkg/apis/authentication/v1
-  - pkg/apis/authentication/v1beta1
-  - pkg/apis/authorization
-  - pkg/apis/authorization/install
-  - pkg/apis/authorization/v1
-  - pkg/apis/authorization/v1beta1
-  - pkg/apis/autoscaling
-  - pkg/apis/autoscaling/install
-  - pkg/apis/autoscaling/v1
-  - pkg/apis/autoscaling/v2alpha1
-  - pkg/apis/batch
-  - pkg/apis/batch/install
-  - pkg/apis/batch/v1
-  - pkg/apis/batch/v2alpha1
-  - pkg/apis/certificates
-  - pkg/apis/certificates/install
-  - pkg/apis/certificates/v1beta1
-  - pkg/apis/extensions
-  - pkg/apis/extensions/install
-  - pkg/apis/extensions/v1beta1
-  - pkg/apis/policy
-  - pkg/apis/policy/install
-  - pkg/apis/policy/v1beta1
-  - pkg/apis/rbac
-  - pkg/apis/rbac/install
-  - pkg/apis/rbac/v1alpha1
-  - pkg/apis/rbac/v1beta1
-  - pkg/apis/settings
-  - pkg/apis/settings/install
-  - pkg/apis/settings/v1alpha1
-  - pkg/apis/storage
-  - pkg/apis/storage/install
-  - pkg/apis/storage/v1
-  - pkg/apis/storage/v1beta1
-  - pkg/util
-  - pkg/util/parsers
-  - pkg/version
-  - rest
-  - rest/watch
-  - tools/auth
-  - tools/clientcmd
-  - tools/clientcmd/api
-  - tools/clientcmd/api/latest
-  - tools/clientcmd/api/v1
-  - tools/metrics
-  - transport
-  - util/cert
-  - util/clock
-  - util/flowcontrol
-  - util/homedir
-  - util/integer
 testImports: []

--- a/glide.yaml
+++ b/glide.yaml
@@ -6,8 +6,6 @@ import:
   version: 9c28e4bbd74e5c3ed7aacbc552b2cab7cfdfe744
 - package: github.com/spf13/viper
   version: 16990631d4aa7e38f73dbbbf37fa13e67c648531
-- package: k8s.io/client-go
-  version: 99c1992389642cae4f41b931eca21827f9cc35b7
 - package: github.com/gorilla/mux
   version: bcd8bc72b08df0f70df986b97f95590779502d31
 - package: github.com/urfave/negroni
@@ -32,3 +30,9 @@ import:
   version: 645ef00459ed84a119197bfb8d8205042c6df63d
 - package: github.com/bypasslane/boxedRice
   version: af9beabff7eebd726c0106cd911149dc6ca7a3b0
+- package: github.com/ericchiang/k8s
+  version: ^0.4.0
+- package: github.com/fsnotify/fsnotify
+  version: ~1.4.2
+- package: github.com/ghodss/yaml
+  version: ^1.0.0

--- a/gozer-web/src/services/DeploymentService.js
+++ b/gozer-web/src/services/DeploymentService.js
@@ -32,7 +32,7 @@ function transformDeploymentToViewObj(deployment) {
 
 function list() {
   return deploymentsResource.get().then(function (response) {
-    return response.data.deployments.map(transformDeploymentToViewObj)
+    return response.data.items.map(transformDeploymentToViewObj)
   });
 }
 

--- a/start.sh
+++ b/start.sh
@@ -2,7 +2,4 @@
 
 set -eu
 
-# Start kube proxy for accessing local kube, ignore if fail.
-kubectl proxy --port=8080 & 2>/dev/null
-
-gzr web --namespace=${NAMESPACE:-bypass}
+gzr web


### PR DESCRIPTION
Use slimmer k8s client, in-cluster client creation, use context for namespace

- Use ericchiang/k8s for a slimmer k8s client with less deps
- Use in-cluster config and fall-back to kubeconfig if that fails
- With this way of loading config namespace is gathered from context
- Use yarn in web build to honor version locks
- Upgrade docker image to use go 1.9